### PR TITLE
ESP-IDF v5.1.2 compatibility

### DIFF
--- a/lib/sprofiler/sprofiler.c
+++ b/lib/sprofiler/sprofiler.c
@@ -9,6 +9,10 @@
 #include <esp_debug_helpers.h>
 #include <errno.h>
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+#include <esp_cpu_utils.h>
+#endif
+
 #include "esp32_perfmon.h"
 
 static const char *TAG = "sprofiler";
@@ -249,7 +253,11 @@ void sprofiler_initialize(uint32_t samples_per_second)
     // initialize task to flush profiling data out and flush on each write
     ESP_LOGI(TAG, "Initializing SProfiler...");
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+    esp_err_t ret = esp_vfs_semihost_register("/host");
+#else
     esp_err_t ret = esp_vfs_semihost_register("/host", NULL);
+#endif
     if (ret != ESP_OK)
     {
         ESP_LOGE(TAG, "Failed to register semihost driver (%s)!", esp_err_to_name(ret));


### PR DESCRIPTION
Minor updates for signature compatibility with ESP-IDF v5.1.2 (and probably v5.0 and higher)

Tested OK on ESP32S3 with adapted sprofiler.py script + KCacheGrind